### PR TITLE
Add support for G920 Driving Force Racing Wheel for Xbox One

### DIFF
--- a/code/index.js
+++ b/code/index.js
@@ -91,7 +91,7 @@ function clone(obj) {
 
 function connect(odo, callback) { // Constable Odo takes many forms.
     /*
-    Connect to a Logitech G29 wheel.
+    Connect to a Logitech G29 or G920 wheel.
     @param   {Object, Function}  odo       Options object or callback function.
     @param   {Function}          callback  Callback function.
     */
@@ -130,7 +130,7 @@ function connect(odo, callback) { // Constable Odo takes many forms.
                 }
 
                 try {
-                    // G29 Wheel init from - https://github.com/torvalds/linux/blob/master/drivers/hid/hid-lg4ff.c
+                    // G29/G920 Wheel init from - https://github.com/torvalds/linux/blob/master/drivers/hid/hid-lg4ff.c
                     relayOS([0xf8, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00])
                     relayOS([0xf8, 0x09, 0x05, 0x01, 0x01, 0x00, 0x00])
 
@@ -157,7 +157,7 @@ function disconnect() {
 
 function findWheel() {
     /*
-    Return the USB location of a Logitech G29 wheel.
+    Return the USB location of a Logitech G29/G920 wheel.
     @return  {String}  devicePath  USB path like: USB_046d_c294_fa120000
     */
     const devices = hid.devices()
@@ -166,11 +166,14 @@ function findWheel() {
     for (let i in devices) {
         // devices[i].vendorId seems to be the only completely reliable property on each OS.
         // devices[i].productId can not be trusted and can sometimes be wildly different.
-        // devices[i].product should be set to 'G29 Driving Force Racing Wheel'.
+        // devices[i].product should match product identifier for G29/G920 wheel
         // devices[i].interface should be 0 on Windows and Linux.
         // devices[i].usagePage should be 1 on Windows and Mac.
         if (devices[i].vendorId === 1133 &&
-            (devices[i].productId === 49743 || devices[i].product === 'G29 Driving Force Racing Wheel') &&
+            (
+              (devices[i].productId === 49743 || devices[i].product === 'G29 Driving Force Racing Wheel') ||
+              (devices[i].productId === 49762 || devices[i].product === 'G920 Driving Force Racing Wheel for Xbox One')
+            ) &&
             (devices[i].interface === 0 || devices[i].usagePage === 1)) {
             devicePath = devices[i].path
             break
@@ -179,7 +182,7 @@ function findWheel() {
 
     if (devicePath === '') {
         if (options.debug) {
-            console.log(color.yellow('findWheel -> Oops, could not find a G29 Wheel. Is it plugged in?\n'))
+            console.log(color.yellow('findWheel -> Oops, could not find a G29/G920 Wheel. Is it plugged in?\n'))
             process.exit()
         }
     } else if (options.debug) {


### PR DESCRIPTION
This library works well for the G920 Wheel! Adding support only required adding this device's details to the connection process.

Not sure how you want to brand this repo, but it could be worth adding note of G920 support to places like the README.md.